### PR TITLE
Correct and optimize recently added patterns

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -844,8 +844,7 @@
     "description": "jQuery plugin for fluid width video embeds",
     "icon": "FitVids.JS.png",
     "scriptSrc": [
-      "fitvids\\.js.+ver=([\\d\\.]+)\\;version:\\1",
-      "fitvids\\.js"
+      "fitvids\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
     ],
     "oss": true,
     "website": "https://fitvidsjs.com/"

--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -187,8 +187,7 @@
     "website": "https://github.com/moxiecode/moxie",
     "oss": true,
     "scriptSrc": [
-      "moxie\\..+\\.js.+ver=([\\d\\.]+)\\;version:\\1",
-      "moxie\\..+\\.js"
+      "moxie\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
     ]
   },
   "MRW": {

--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -1587,8 +1587,7 @@
     "description": "Orbit is a jQuery slider.",
     "oss": true,
     "scriptSrc": [
-      "orbit.?([\\d\\.]{2,}[\\d]).+\\.js\\;version:\\1",
-      "orbit.+\\.js"
+      "orbit([\\d.]{2,}[\\d])?\\.js\\;version:\\1"
     ],
     "website": "https://zurb.com/playground/orbit-jquery-image-slider"
   },

--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -2157,8 +2157,7 @@
     "icon": "plupload.png",
     "oss": true,
     "scriptSrc": [
-      "plupload\\..+\\.js.+ver=([\\d.]+)\\;version:\\1",
-      "plupload\\..+\\.js"
+      "plupload\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
     ],
     "website": "https://www.plupload.com/"
   },

--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -5224,8 +5224,7 @@
     "description": "Configurable JavaScript/CSS spinner that can be used as a resolution-independent loading indicator",
     "icon": "spin.js.png",
     "scriptSrc": [
-      "spin(?:.+)?\\.js(?:\\?ver=([\\d\\.]+))?\\;version:\\1",
-      "spin(?:.+)?\\.js"
+      "spin\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
     ],
     "oss": true,
     "website": "https://spin.js.org/"


### PR DESCRIPTION
Related to #2, #3, #4, #5, and #6.

I'd strongly suggest verifying with regex101.com.

To be clear these have been corrected/optimized by:
- Removing the matcher for random characters before the `.js`
- Making the version portion optional so it does require two patterns.
- Removing the escaping on period within character class declarations (square brackets) since it's literal there already.

Here's a bookmark for just one of them: https://regex101.com/r/KWgG6C/1