### PR TITLE
Fix typo in a header name

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -371,7 +371,7 @@
       "server": "Fastly",
       "x-fastly-origin": "",
       "x-fastly-request-id": "",
-      "x-via-fastly:": ""
+      "x-via-fastly": ""
     },
     "icon": "Fastly.svg",
     "pricing": [


### PR DESCRIPTION
Found an extra `:` in a header list:
```
"x-via-fastly:"
```
This is a quick change to remove it.