### PR TITLE
elgg image fix

### DIFF
--- a/src/images/icons/Elgg.svg
+++ b/src/images/icons/Elgg.svg
@@ -6,8 +6,7 @@
 	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
 	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
 ]>
-<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
 	 x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 <g>
 	<g>


### PR DESCRIPTION
The image had some weird XML namespace declarations that were causing exception in the java parser library we use. Trimming them does not seem to negatively impact the image's rendering.

Looks fine in:
- kali thumb nail
- kali default image viewer
- Eclipse image viewer
- GitHub web UI

```
2024-02-08 11:00:25,769 [AWT-EventQueue-0] ERROR StaxSVGLoader - Error while parsing SVG.
javax.xml.stream.XMLStreamException: ParseError at [row,col]:[9,54]
Message: http://www.w3.org/TR/1999/REC-xml-names-19990114#EmptyPrefixedAttName?prefix="xmlns",localpart="x",rawname="xmlns:x"
	at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.next(XMLStreamReaderImpl.java:652) ~[?:?]
	at com.sun.xml.internal.stream.XMLEventReaderImpl.nextEvent(XMLEventReaderImpl.java:83) ~[?:?]
	at com.github.weisj.jsvg.parser.StaxSVGLoader.load(StaxSVGLoader.java:86) ~[?:?]
	at com.github.weisj.jsvg.parser.SVGLoader.load(SVGLoader.java:72) ~[?:?]
	at com.github.weisj.jsvg.parser.SVGLoader.load(SVGLoader.java:64) ~[?:?]
	at com.github.weisj.jsvg.parser.SVGLoader.load(SVGLoader.java:52) ~[?:?]
	at com.github.weisj.jsvg.parser.SVGLoader.load(SVGLoader.java:46) ~[?:?]
```

```diff
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+        xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
         x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 <g>
        <g>
 ```