### PR TITLE
Fix typo in D3.js detection

### DIFF
--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -9,7 +9,7 @@
     "js": {
       "d3.version": "^(.+)$\\;version:\\1"
     },
-    "scriptSrc": "/d3(?:\\. v\\d+)?(?:\\.min)?\\.js",
+    "scriptSrc": "/d3(?:\\.v\\d+)?(?:\\.min)?\\.js",
     "website": "https://d3js.org"
   },
   "DDoS-Guard": {


### PR DESCRIPTION
Correct typo in D3.js scriptSrc detection.

Example URL: https://d3js.org/d3.v3.min.js