### PR TITLE
Update regex for Zeleris

### DIFF
--- a/src/technologies/z.json
+++ b/src/technologies/z.json
@@ -186,7 +186,7 @@
     "description": "Zeleris provides door to door shipment delivery to Ireland, UK and the EU.",
     "requiresCategory": 6,
     "text": [
-      "\\Zeleris\\b"
+      "\\bZeleris\\b"
     ],
     "website": "https://www.zeleris.com"
   },


### PR DESCRIPTION
[`regex` crate](https://github.com/rust-lang/regex) from Rust complains ["unrecognized escape sequence" on `\Z`](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1fa04888591fc1a47eddb67fa18663c6). I believe the `\\` should be `\\b`.