### PR TITLE
Erlang: remove OTP prefix from version string

### DIFF
--- a/src/technologies/e.json
+++ b/src/technologies/e.json
@@ -2293,7 +2293,7 @@
     "cpe": "cpe:2.3:a:erlang:erlang\\/otp:*:*:*:*:*:*:*:*",
     "description": "Erlang is a general-purpose, concurrent, functional programming language, and a garbage-collected runtime system.",
     "headers": {
-      "Server": "Erlang( OTP/(?:[\\d.ABR-]+))?\\;version:\\1"
+      "Server": "Erlang(?: OTP/([\\d.ABR-]+))?\\;version:\\1"
     },
     "icon": "Erlang.svg",
     "website": "https://www.erlang.org"


### PR DESCRIPTION
This changes the returned Erlang version from e.g " OTP/20" to just "20".

This makes the version string easier to use in software using the results.

Example: https://couchdb.ucr.fr/ 