### PR TITLE
Add jQuery Popup overlay

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -34,7 +34,7 @@
       18,
       53
     ],
-    "cpe": "cpe:2.3:a:glpi-project:glpi:*:*:*:*:*:*:*:* ",
+    "cpe": "cpe:2.3:a:glpi-project:glpi:*:*:*:*:*:*:*:*",
     "description": "GLPI is an open-source IT Asset Management, issue tracking and service desk system.",
     "dom": {
       "div[id*='footer-login'] > a": {

--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -1308,7 +1308,9 @@
       59
     ],
     "description": "jQuery Popup Overlay is a responsive overlay which lets you create modal windows, tooltips, and more.",
-    "scriptSrc": "(\\d+\\.\\d+\\.\\d+)/jquery\\.popupoverlay\\.js\\;version:\\1",
+    "scriptSrc": [
+      "(\\d+\\.\\d+\\.\\d+)/jquery\\.popupoverlay\\.js\\;version:\\1",
+    ],
     "website": "https://www.npmjs.com/package/jquery-popup-overlay"
   },
   "jQuery Sparklines": {

--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -1210,7 +1210,7 @@
     "scriptSrc": [
       "jquery",
       "/jquery(?:-(\\d+\\.\\d+\\.\\d+))[/.-]\\;version:\\1",
-      "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-][^u]\\;version:\\1"
+      "/(\\d+\\.\\d+\\.\\d+)/jquery(?!\\.popupoverlay\\.js)[/.-][^u]\\;version:\\1"
     ],
     "website": "https://jquery.com"
   },
@@ -1302,6 +1302,14 @@
       "jquery-modal/([\\d\\.]+)/jquery\\.modal\\.min\\.js\\;version:\\1"
     ],
     "website": "https://jquerymodal.com"
+  },
+  "jQuery Popup Overlay": {
+    "cats": [
+      59
+    ],
+    "description": "jQuery Popup Overlay is a responsive overlay which lets you create modal windows, tooltips, and more.",
+    "scriptSrc": "(\\d+\\.\\d+\\.\\d+)/jquery\\.popupoverlay\\.js\\;version:\\1",
+    "website": "https://www.npmjs.com/package/jquery-popup-overlay"
   },
   "jQuery Sparklines": {
     "cats": [

--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -1309,7 +1309,7 @@
     ],
     "description": "jQuery Popup Overlay is a responsive overlay which lets you create modal windows, tooltips, and more.",
     "scriptSrc": [
-      "(\\d+\\.\\d+\\.\\d+)/jquery\\.popupoverlay\\.js\\;version:\\1",
+      "(\\d+\\.\\d+\\.\\d+)/jquery\\.popupoverlay\\.js\\;version:\\1"
     ],
     "website": "https://www.npmjs.com/package/jquery-popup-overlay"
   },


### PR DESCRIPTION
jQuery Popup overlay is getting mis-identified as jQuery.

I'm afraid I don't have 10 sites - but here is one https://wallacelive.wallacecollection.org/eMP/eMuseumPlus.

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/d4a0aeac-2f6b-4a1e-8620-5758e8b9b0c7" />

