### PR TITLE
fix: remove leading greedy regex operator on scripts pattern

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -3816,7 +3816,7 @@
       "freemium"
     ],
     "scripts": [
-      ".*altcha\\.(org|js)"
+      "altcha\\.(org|js)"
     ],
     "website": "https://altcha.org"
   },

--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -2943,7 +2943,7 @@
       "grafana\\..+\\.com/public/build/"
     ],
     "scripts": [
-      ".+latestVersion\":\"[\\d\\.\\w\\-]+\"\\,\"version\":\"([\\d\\.]+)\\;version:\\1\\;confidence:75"
+      "latestVersion\":\"[\\d\\.\\w\\-]+\"\\,\"version\":\"([\\d\\.]+)\\;version:\\1\\;confidence:75"
     ],
     "website": "https://grafana.com"
   },


### PR DESCRIPTION
The leading greedy operator is causing backtracing when matched, and because `scripts` pattern are tested against potentially a large amount of character (by large I mean multiple MB), their performance is important. 

These two (Grafana & Altech) are the only one I have found, as other pattern types are usually tested against much smaller text,  thus the performance hit is not really noticeable.

It should not impact the detection. We've been running this patch for a few months without issue, and a CPU thanking us!