### PR TITLE
Fix jquery definition misidentifying popupoverlay

### DIFF
--- a/src/technologies/j.json
+++ b/src/technologies/j.json
@@ -1382,7 +1382,7 @@
     "scriptSrc": [
       "jquery",
       "/jquery(?:-(\\d+\\.\\d+\\.\\d+))[/.-]\\;version:\\1",
-      "/(\\d+\\.\\d+\\.\\d+)/jquery[/.-][^u]\\;version:\\1"
+      "/(\\d+\\.\\d+\\.\\d+)/jquery(?!\\.popupoverlay\\.js)[/.-][^u]\\;version:\\1"
     ],
     "website": "https://jquery.com"
   },


### PR DESCRIPTION
My change which stops popupoverlay being mistakenly identified as jQuery in this [PR](https://github.com/enthec/webappanalyzer/pull/206) has been overridden.

The current regular expression extracts a jquery version of 1.7.13 from this URL:

https://some-url/some-path/jquery-popup-overlay@**1.7.13/jquery**.popupoverlay.js

The addition of (?!\.popupoverlay\.js) in the regular expression is a negative lookahead that serves to exclude any matches.

