### PR TITLE
fix: regex performance

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -4240,7 +4240,7 @@
       "freemium"
     ],
     "scripts": [
-      ".*altcha\\.(org|js)"
+      "altcha\\.(org|js)"
     ],
     "website": "https://altcha.org"
   },


### PR DESCRIPTION
Followup of #207
One of the change has been overwritten after the tech resync from early July. We just updated our signature, thus why it stayed undetected for so long...