### PR TITLE
Fix Google Font API website URL

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -2929,7 +2929,7 @@
     "scriptSrc": [
       "googleapis\\.com/.+webfont"
     ],
-    "website": "https://google.com/fonts"
+    "website": "https://fonts.google.com/"
   },
   "Google Forms": {
     "cats": [


### PR DESCRIPTION
Update website URL from https://google.com/fonts to https://fonts.google.com/

Fixes #218