### PR TITLE
Update next.js vendor

### DIFF
--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -1244,7 +1244,7 @@
     "cookies": {
       "NEXT_LOCALE": ""
     },
-    "cpe": "cpe:2.3:a:zeit:next.js:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:vercel:next.js:*:*:*:*:*:*:*:*",
     "description": "Next.js is a React framework for developing single page Javascript applications.",
     "headers": {
       "x-powered-by": "^Next\\.js ?([0-9.]+)?\\;version:\\1"


### PR DESCRIPTION
Zeit has changed its name to vercel

https://vercel.com/blog/zeit-is-now-vercel

This update is particularly important as [CVE-2025-55182](https://nvd.nist.gov/vuln/detail/CVE-2025-55182)  affects this very technology.