### PR TITLE
Remove common false positive USPS match in u.json

### DIFF
--- a/src/technologies/u.json
+++ b/src/technologies/u.json
@@ -189,7 +189,6 @@
       6
     ],
     "text": [
-      "\\bUSPS\\b",
       "\\bUnited States Postal Service\\b"
     ],
     "website": "https://www.usps.com"


### PR DESCRIPTION
Removes 'USPS' text match and only leave 'United States Postal Service' to prevent false positive matches.

The (sub)string "USPS" occurs on many other webpages.