### PR TITLE
Add definitions for turnstile wordpress plugin

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -5308,6 +5308,20 @@
     "saas": true,
     "website": "https://www.cloudflare.com/products/turnstile"
   },
+  "Cloudflare Turnstile for WooCommerce": {
+    "cats": [
+      87
+    ],
+    "description": "Cloudflare Turnstile Integration Plugin for WooCommerce adds Cloudflare Turnstile support to WooCommerce forms.",
+    "icon": "CloudFlare.svg",
+    "requires": [
+      "WordPress"
+    ],
+    "scriptSrc": [
+      "/wp-content/plugins/simple-cloudflare-turnstile/js/integrations/woocommerce\\.js(?:\\?ver=([\\d.]+))?\\;version:\\1"
+    ],
+    "website": "https://wordpress.org/plugins/simple-cloudflare-turnstile/"
+  },
   "Cloudflare Workers": {
     "cats": [
       62

--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -3583,8 +3583,9 @@
       "WordPress"
     ],
     "scriptSrc": [
-      "woocommerce",
-      "/woocommerce(?:\\.min)?\\.js(?:\\?ver=([0-9.]+))?\\;version:\\1"
+      "^(?!.*?/wp-content/plugins/[^/]+/js/integrations/woocommerce\\.js(?:\\?ver=[\\d.]+)?$).*woocommerce",
+      "^(?!.*?/wp-content/plugins/[^/]+/js/integrations/woocommerce\\.js(?:\\?ver=[\\d.]+)?$).*/woocommerce(?:\\.min)?\\.js(?:\\?ver=([0-9.]+))?\\;version:\\1"
+
     ],
     "website": "https://woocommerce.com"
   },


### PR DESCRIPTION
**Summary**

Fixes incorrect detection of WooCommerce technology version from wordpress plugin scripts.

**Details**

While reviewing detection results, I found that the script path
`/plugins/simple-cloudflare-turnstile/js/integrations/woocommerce.js?ver=1.3`
was being incorrectly identified as a WooCommerce technology with version 1.3.

**Changes**

* Added a new technology definition for Cloudflare Turnstile for WooCommerce to properly classify this integration.
* Updated the WooCommerce detection regex to ignore script sources matching the pattern:
    `/plugins/<any-plugin>/js/integrations/woocommerce.js`
