### PR TITLE
Add MVD Studio platform

### DIFF
--- a/src/images/icons/MVD Studio.svg
+++ b/src/images/icons/MVD Studio.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="10" fill="#0F172A"/>
+  <text x="32" y="40" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="700" fill="#FFFFFF" text-anchor="middle" letter-spacing="-0.5">MVD</text>
+</svg>

--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -7083,6 +7083,27 @@
     "saas": true,
     "website": "https://www.mux.com"
   },
+  "MVD Studio": {
+    "cats": [
+      1,
+      6
+    ],
+    "description": "MVD Studio is a Laravel-based platform built by MVD Studio (Uruguay) for e-commerce stores and bespoke web applications.",
+    "icon": "MVD Studio.svg",
+    "implies": [
+      "Laravel",
+      "PHP"
+    ],
+    "headers": {
+      "X-Built-By": "MVD Studio",
+      "X-Generator": "MVD Studio",
+      "X-Powered-By": "MVD Studio"
+    },
+    "meta": {
+      "generator": "MVD Studio"
+    },
+    "website": "https://mvdstudio.com.uy"
+  },
   "My Agile Privacy": {
     "cats": [
       67


### PR DESCRIPTION
Adds detection for **MVD Studio** — an Uruguayan studio that builds custom Laravel-based e-commerce stores and web apps (https://mvdstudio.com.uy).

## Detection patterns

Sites built by MVD Studio set:

- **HTTP headers** (global middleware):
  ```
  X-Powered-By: MVD Studio
  X-Built-By: MVD Studio
  X-Generator: MVD Studio
  ```
- **HTML meta** in `<head>`:
  ```html
  <meta name="generator" content="MVD Studio">
  ```

## Implies

`Laravel`, `PHP` — MVD Studio's stack is Laravel 12 on PHP 8.3+.

## Categories

- 1 (CMS) — they ship a custom admin/CMS layer.
- 6 (Ecommerce) — primary use case so far.

## Live example

- https://staging.laquia.com.uy (La Quia — fashion e-commerce). Headers and meta are visible in any response.

## Icon

Included `src/images/icons/MVD Studio.svg` — simple monogram. Happy to swap if the project prefers a different style.
