### PR TITLE
Add VertaFlow (Analytics, Booking, Chat, Forms)

### DIFF
--- a/src/images/icons/VertaFlow.svg
+++ b/src/images/icons/VertaFlow.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#1c1c2e"/>
+  <path d="M6.5 8 L16 24 L25.5 8" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/technologies/v.json
+++ b/src/technologies/v.json
@@ -1145,6 +1145,50 @@
     "saas": true,
     "website": "https://www.verseone.com"
   },
+  "VertaFlow Analytics": {
+    "cats": [
+      10
+    ],
+    "description": "VertaFlow Analytics is a lightweight, cookie-free, first-party analytics pixel that tracks pageviews, clicks, scroll depth, and UTM campaigns, sending events to VertaFlow CRM.",
+    "icon": "VertaFlow.svg",
+    "scriptSrc": [
+      "vertaflow\\.io/v1/pixel\\.js"
+    ],
+    "website": "https://vertaflow.io"
+  },
+  "VertaFlow Booking": {
+    "cats": [
+      72
+    ],
+    "description": "VertaFlow Booking is an embeddable appointment-scheduling widget that syncs bookings to VertaFlow CRM.",
+    "icon": "VertaFlow.svg",
+    "scriptSrc": [
+      "vertaflow\\.io/v1/book\\.js"
+    ],
+    "website": "https://vertaflow.io"
+  },
+  "VertaFlow Chat": {
+    "cats": [
+      52
+    ],
+    "description": "VertaFlow Chat is a lightweight embeddable chat widget that routes messages to VertaFlow CRM tickets.",
+    "icon": "VertaFlow.svg",
+    "scriptSrc": [
+      "vertaflow\\.io/v1/chat\\.js"
+    ],
+    "website": "https://vertaflow.io"
+  },
+  "VertaFlow Forms": {
+    "cats": [
+      110
+    ],
+    "description": "VertaFlow Forms is an embeddable lead-capture form widget that routes submissions to VertaFlow CRM.",
+    "icon": "VertaFlow.svg",
+    "scriptSrc": [
+      "vertaflow\\.io/v1/form\\.js"
+    ],
+    "website": "https://vertaflow.io"
+  },
   "Vertex": {
     "cats": [
       80


### PR DESCRIPTION
Adds technology definitions for **VertaFlow** (https://vertaflow.io), a first-party, cookie-free CRM + analytics platform for service businesses.

Four embeddable tags, each served from `api.vertaflow.io/v1/<tag>.js` (verified live, HTTP 200):

| Technology | Script | Category |
|---|---|---|
| VertaFlow Analytics | `pixel.js` | Analytics (10) |
| VertaFlow Forms | `form.js` | Form builders (110) |
| VertaFlow Chat | `chat.js` | Live chat (52) |
| VertaFlow Booking | `book.js` | Appointment scheduling (72) |

Icon (`VertaFlow.svg`) included. Fingerprints are `scriptSrc` regexes on the canonical CDN path.