### PR TITLE
Add DNS TXT detection to Notion

### DIFF
--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -2386,6 +2386,11 @@
     ],
     "cpe": "cpe:2.3:a:notion:notion:*:*:*:*:*:*:*:*",
     "description": "Notion is a collaboration platform with modified Markdown support that integrates kanban boards, tasks, wikis, and database.",
+    "dns": {
+      "TXT": [
+        "notion-domain-verification="
+      ]
+    },
     "dom": [
       "html.notion-html"
     ],


### PR DESCRIPTION
## Summary

Adds a DNS `TXT` domain-verification fingerprint to the existing **Notion** entry, which currently only detects via DOM (`html.notion-html`). This catches Notion-managed domains that verify ownership through the `notion-domain-verification` TXT record.

**Verifiable real-world example** — `aarin.com.br`:

```
$ dig @8.8.8.8 +short TXT aarin.com.br | grep notion
"notion-domain-verification=LJ19T1Y6CYEQ0ywD0Rn9sQ6z6goVg1zefLpPH5StjoV"
```

The fingerprint matches the generic `notion-domain-verification=` prefix so it detects any verified domain, not a single instance — following the same convention as existing entries (`dropbox-domain-verification`, `heroku-domain-verification`, `onetrust-domain-verification=`, etc.).

## Changes

- `src/technologies/n.json` — existing `Notion` entry gains a `dns.TXT` fingerprint (no other fields changed; DOM detection preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)