### PR TITLE
Add Cartline (ecommerce platform)

### DIFF
--- a/src/images/icons/Cartline.svg
+++ b/src/images/icons/Cartline.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="Cart Line">
+  <defs><linearGradient id="ca" x1="0" y1="1" x2="1" y2="0"><stop offset="0" stop-color="#F97316"/><stop offset="1" stop-color="#FB7185"/></linearGradient></defs>
+  <rect x="8"  y="26" width="8.5" height="16" rx="4.25" fill="url(#ca)"/>
+  <rect x="19.75" y="16" width="8.5" height="26" rx="4.25" fill="url(#ca)"/>
+  <rect x="31.5" y="6"  width="8.5" height="36" rx="4.25" fill="url(#ca)"/>
+</svg>

--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -1351,6 +1351,25 @@
     ],
     "website": "https://www.cartkit.com"
   },
+  "Cartline": {
+    "cats": [
+      6
+    ],
+    "description": "Cartline is a Pakistani ecommerce and WhatsApp-commerce platform for creating online stores with cart, checkout and order management. Part of the One Line commerce suite.",
+    "headers": {
+      "x-cartline-platform": "cartline\\.pk"
+    },
+    "icon": "Cartline.svg",
+    "js": {
+      "Cartline.platform": "^Cartline$"
+    },
+    "meta": {
+      "application-name": "^Cartline$",
+      "generator": "^Cartline$"
+    },
+    "saas": true,
+    "website": "https://cartline.pk"
+  },
   "CARTO Analytics": {
     "cats": [
       35


### PR DESCRIPTION
Adds **Cartline** — a Pakistani ecommerce & WhatsApp-commerce platform for building online stores (cart, checkout, order management). Category: **Ecommerce (6)**.

**Fingerprints** (all present on every Cartline storefront):
- `<meta name="generator" content="Cartline">` and `<meta name="application-name" content="Cartline">`
- `window.Cartline` JS global (`Cartline.platform === "Cartline"`)
- `X-Cartline-Platform: https://cartline.pk` response header

**10+ live sites using Cartline:**
- https://mr-bilal-chef.cartline.pk
- https://loomin.cartline.pk
- https://hadeed.cartline.pk
- https://herbline.cartline.pk
- https://muted.cartline.pk
- https://bin-b.cartline.pk
- https://wahab-niazi.cartline.pk
- https://dua-khan.cartline.pk
- https://ad-foods.cartline.pk
- https://meebu.cartline.pk
- https://aimis.cartline.pk
- https://shahbaz-ahmad.cartline.pk

Website: https://cartline.pk · Icon added at `src/images/icons/Cartline.svg`.
