### PR TITLE
fix: prevent substring false positives in dc.js and Bootstrap scriptSrc rules

### DIFF
--- a/src/technologies/b.json
+++ b/src/technologies/b.json
@@ -4386,7 +4386,7 @@
       "jQuery.fn.tooltip.Constructor.VERSION": "^(.+)$\\;version:\\1"
     },
     "scriptSrc": [
-      "bootstrap(?:[^>]*?([0-9a-fA-F]{7,40}|[\\d]+(?:.[\\d]+(?:.[\\d]+)?)?)|)[^>]*?(?:\\.min)?\\.js\\;version:\\1"
+      "(?:/|-)bootstrap(?:[^/]*?([0-9a-fA-F]{7,40}|[\\d]+(?:\\.[\\d]+(?:\\.[\\d]+)?)?)|)[^/]*?(?:\\.min)?\\.js\\;version:\\1"
     ],
     "website": "https://getbootstrap.com"
   },

--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -807,7 +807,7 @@
       "dcAPIKey": ""
     },
     "scriptSrc": [
-      "(?:((?:\\d+\\.)+\\d+)\\/(?:dc\\/)?)?dc(?:\\.leaflet)?\\.js\\;version:\\1"
+      "(?:((?:\\d+\\.)+\\d+)\\/(?:dc\\/)?)?(?:/|-)dc(?:\\.leaflet)?\\.js\\;version:\\1"
     ],
     "website": "https://dc-js.github.io/dc.js/"
   },


### PR DESCRIPTION
Hi maintainers, 

I encountered false positives for both `dc.js` and `Bootstrap` when scanning websites built with Framer (e.g., `https://fundraisly.com/`). The current `scriptSrc` regex patterns lack proper URL path boundary constraints, causing them to match substrings within long hash strings.

#### 1. dc.js False Positive
- **Failing URL**: `https://framer.com/bootstrap.7bfce40f145f2895acab3198e0c542f6ad79a5dc.js`
- **Root Cause**: The pattern `dc(?:\.leaflet)?\.js` matches the trailing `dc.js` in the hash string `...a5dc.js` because there is no left-boundary assertion.
- **Fix**: Added `(?:/|-)` before `dc` to enforce a valid URL path separator or hyphen boundary.

#### 2. Bootstrap False Positive
- **Failing URL**: `https://framer.com/bootstrap.7bfce40f145f2895acab3198e0c542f6ad79a5dc.js`
- **Root Cause**: The pattern uses `[^>]*?` which was likely intended for HTML `<script>` tag parsing. However, `scriptSrc` receives pure URL strings where `>` does not exist. This causes `[^>]*?` to act like `.*?`, greedily swallowing path separators and matching unrelated trailing characters.
- **Fix**: 
  1. Added `(?:/|-)` before `bootstrap` to enforce strict path boundaries.
  2. Replaced `[^>]*?` with `[^/]*?` to strictly confine the match within the current URL path segment.
  3. Escaped the literal dot in the version capture group `(?:\\.[\\d]+` for better regex accuracy.

#### Modified Patterns:

**dc.js** (`src/technologies/d.json`):

"(?:((?:\\d+\\.)+\\d+)\\/(?:dc\\/)?)?(?:/|-)dc(?:\\.leaflet)?\\.js\\;version:\\1"

**Bootstrap** (src/technologies/b.json):

"(?:/|-)bootstrap(?:[^/]*?([0-9a-fA-F]{7,40}|[\\d]+(?:\\.[\\d]+(?:\\.[\\d]+)?)?)|)[^/]*?(?:\\.min)?\\.js\\;version:\\1"