### PR TITLE
Add Commercy

### DIFF
--- a/src/images/icons/Commercy.svg
+++ b/src/images/icons/Commercy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <circle cx="11.5" cy="16" r="8" fill="#2563EB" fill-opacity=".5"/>
+  <circle cx="20.5" cy="16" r="8" fill="#2563EB"/>
+</svg>

--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -6793,6 +6793,25 @@
     ],
     "website": "https://commercio.com"
   },
+  "Commercy": {
+    "cats": [
+      6
+    ],
+    "description": "Commercy is an Argentine commerce platform that combines an online store, point of sale, inventory and ARCA/AFIP electronic invoicing in a single system.",
+    "icon": "Commercy.svg",
+    "implies": [
+      "Next.js"
+    ],
+    "meta": {
+      "generator": "^Commercy$"
+    },
+    "pricing": [
+      "low",
+      "recurring"
+    ],
+    "saas": true,
+    "website": "https://commercy.com.ar"
+  },
   "Common Ground": {
     "cats": [
       6


### PR DESCRIPTION
Adds **Commercy**, an Argentine commerce platform that combines an online store, point of sale, inventory and ARCA/AFIP electronic invoicing in a single system.

## Detection

Storefronts emit a generator meta tag:

```html
<meta name="generator" content="Commercy"/>
```

```json
"meta": { "generator": "^Commercy$" }
```

Anchored on both ends so it can't collide with other technologies.

## Live sites using it

All 17 are in production and currently serve the generator tag — verified at the time of this PR:

1. https://seryal.com.ar
2. https://viverolafloresta.commercy.com.ar
3. https://imprimi3d.commercy.com.ar
4. https://imprimi3d-quilmes.commercy.com.ar
5. https://imprimi3d-villaadelina.commercy.com.ar
6. https://imprimi3d-ramalpilar.commercy.com.ar
7. https://todo-limpio.commercy.com.ar
8. https://karimeboutique.commercy.com.ar
9. https://suplementos.commercy.com.ar
10. https://clubnaturalfit.commercy.com.ar
11. https://overtech.commercy.com.ar
12. https://thehood.commercy.com.ar
13. https://allimport.commercy.com.ar
14. https://lyra.commercy.com.ar
15. https://corral.commercy.com.ar
16. https://mdvind.commercy.com.ar
17. https://asda.commercy.com.ar

Quick check:

```bash
curl -s https://seryal.com.ar/ | grep -o '<meta name="generator"[^>]*>'
```

The platform runs 98 storefronts in production; the list above is limited to live merchant stores, excluding demo/template sites so the evidence reflects real usage.

## Notes

- `cats: [6]` (Ecommerce), matching how other regional platforms in this repo are categorised.
- `implies: ["Next.js"]` — the storefronts are server-rendered with Next.js.
- Icon added as a 32×32 square SVG at `src/images/icons/Commercy.svg`.
- Entry inserted in case-insensitive alphabetical order between `Commercio` and `Common Ground`; diff is 19 insertions and no deletions.
- All repo validators pass locally: `structure`, `schema`, `order`, `category`, `group` and `icon_path`.