### PR TITLE
Remove incorrect scriptSrc from Clickbank (points to Rewardful's domain)

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -4386,9 +4386,6 @@
     "js": {
       "cbtb": ""
     },
-    "scriptSrc": [
-      "r\\.wdfl\\.co"
-    ],
     "website": "https://www.clickbank.com/"
   },
   "Clickbooq": {


### PR DESCRIPTION
## Problem

Clickbank's `scriptSrc` is set to `r\.wdfl\.co`, which is 
Rewardful's domain. This causes any site using Rewardful to be 
falsely detected as Clickbank.

## Fix

Removed the incorrect `scriptSrc` entry. The remaining `dom` and 
`js` rules are sufficient for accurate Clickbank detection:
- `dom`: matches `pay.clickbank.net` and `hop.clickbank.net` URLs
- `js`: matches the `cbtb` global variable

If a correct `scriptSrc` pattern is known, it can be added back.