### PR TITLE
Liferay: add cookie + HTML signals (header/JS-only misses hardened installs)

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -1662,11 +1662,19 @@
     "cats": [
       1
     ],
+    "cookies": {
+      "GUEST_LANGUAGE_ID": "",
+      "COOKIE_SUPPORT": "\\;confidence:50"
+    },
     "cpe": "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
     "description": "Liferay is an open-source company that provides free documentation and paid professional service to users of its software.",
     "headers": {
       "Liferay-Portal": "[a-z\\s]+([\\d.]+)\\;version:\\1"
     },
+    "html": [
+      "Liferay\\.(?:Util|Language|ThemeDisplay|AUI)",
+      "id=\"_com_liferay_"
+    ],
     "icon": "Liferay.svg",
     "implies": [
       "Java"


### PR DESCRIPTION
### Summary
The current Liferay fingerprint matches only the `Liferay-Portal` response header and the `window.Liferay` JS global:

```json
"headers": { "Liferay-Portal": "[a-z\\s]+([\\d.]+)\;version:\\1" },
"js": { "Liferay": "" }
```

Hardened / CDN-fronted Liferay installs commonly **strip the `Liferay-Portal` header**, and static (non-JS) analysis can't observe `window.Liferay` — so Liferay goes undetected despite unmistakable markers in the HTML and cookies.

### Change
Adds unique static-response signals, keeping the existing header/JS matches and version capture:

- **html**
  - `Liferay\.(?:Util|Language|ThemeDisplay|AUI)` — Liferay client-side JS API namespaces.
  - `id="_com_liferay_` — Liferay portlet DOM id prefix.
- **cookies**
  - `GUEST_LANGUAGE_ID` — Liferay i18n cookie.
  - `COOKIE_SUPPORT` at `confidence:50` (more generic name → not standalone).

### Verified on a real hardened install
`https://www.javeriana.edu.co` (Universidad Javeriana): **no** `Liferay-Portal` header, but `Liferay.AUI` ×19, `id="_com_liferay_` ×519, and a `COOKIE_SUPPORT` cookie. Detected as Liferay with this change; undetected without it. Patterns chosen to be Liferay-unique per the "find unique strings" guideline.

_Assisted by Claude Code._