### PR TITLE
Add dns.TXT fingerprints to Canva, Microsoft 365 and TeamViewer

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -652,6 +652,11 @@
       51
     ],
     "description": "Canva is an online graphic design platform that allows users to create various visual content using pre-designed templates and a library of elements.",
+    "dns": {
+      "TXT": [
+        "canva-site-verification="
+      ]
+    },
     "icon": "Canva.svg",
     "js": {
       "canva_debounceResize": "",

--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -3859,6 +3859,9 @@
     "dns": {
       "MX": [
         "outlook\\.com"
+      ],
+      "TXT": [
+        "^MS=(?:ms[\\w-]+|[0-9A-Fa-f]{40})$"
       ]
     },
     "icon": "Microsoft 365.svg",

--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -1485,6 +1485,11 @@
       45
     ],
     "description": "TeamViewer is a network and IT systems uptime monitoring service, formerly known as Monitis.",
+    "dns": {
+      "TXT": [
+        "teamviewer-sso-verification="
+      ]
+    },
     "icon": "TeamViewer.svg",
     "pricing": [
       "low",


### PR DESCRIPTION
Adds the `dns.TXT` method to three technologies that already exist in the catalog. No new entries, no new icons, no new categories.

## Method

Each pattern was compiled case-insensitively and run against a corpus of **6128 TXT records from 178
mutually independent apex domains** (no shared parent organisation; mixed geography and industry;
resolver `1.1.1.1`; multi-string TXT values concatenated before matching, as a standard resolver
does). A match on any record other than the intended vendor token counts as a false positive.
**There were none, for any pattern below.**

<details><summary>Calibration: the same corpus, measured against patterns this catalog already accepts</summary>

| Pattern already accepted upstream | Domains | Records |
|---|---|---|
| `anthropic-domain-verification` | 94 | 96 |
| `stripe-verification=` | 66 | 229 |
| `cursor-domain-verification` | 63 | 65 |
| `onetrust-domain-verification=` | 62 | 87 |
| `status-page-domain-verification=` | 35 | 40 |
| `notion-domain-verification=` | 28 | 33 |
| `mixpanel-domain-verify` | 27 | 29 |
| `zapier-domain-verification-challenge=` | 26 | 26 |
| `dropbox-domain-verification` | 23 | 24 |
| `segment-site-verification` | 23 | 26 |
| `lovable_verification=` | 8 | 8 |
| `loom-verification` | 4 | 4 |
| `windsurf-verification=` | 4 | 4 |
| `heroku-domain-verification` | 0 | 0 |

Every pattern proposed here corroborates on more domains than `lovable_verification=` (8), and the
larger ones exceed `anthropic-domain-verification` (94) and `stripe-verification=` (66).

</details>

### Canva

Pattern: `canva-site-verification=` — **38 domains** / 40 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://airbnb.com
- https://amazon.com
- https://amplitude.com
- https://asana.com
- https://atlassian.com
- https://cloudflare.com
- https://databricks.com
- https://grab.com
- https://gympass.com
- https://hashicorp.com
- https://hp.com
- https://hubspot.com
- https://ifood.com.br
- https://infosys.com
- …and 24 more

</details>

### Microsoft 365

Pattern: `^MS=(?:ms[\w-]+|[0-9A-Fa-f]{40})$` — **123 domains** / 175 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://99app.com
- https://adyen.com
- https://airbnb.com
- https://airtable.com
- https://akamai.com
- https://amazon.com
- https://ambev.com.br
- https://americanas.com
- https://amplitude.com
- https://assai.com.br
- https://atlassian.com
- https://b3.com.br
- https://bb.com.br
- https://bloomberg.com
- …and 109 more

</details>

### TeamViewer

Pattern: `teamviewer-sso-verification=` — **19 domains** / 22 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://carrefour.com
- https://creditas.com
- https://datadoghq.com
- https://digitalocean.com
- https://hp.com
- https://ifood.com.br
- https://intel.com
- https://inter.co
- https://jamf.com
- https://jumpcloud.com
- https://nvidia.com
- https://picpay.com
- https://shopify.com
- https://smartsheet.com
- …and 5 more

</details>

## Note on Microsoft 365

The entry declares only `dns.MX: outlook\.com` today, so any tenant running Microsoft 365 for
identity and collaboration while delivering mail through another provider is missed entirely. Three
`MS=` body shapes were observed across the corpus and the pattern covers all of them:

```
MS=ms85661547
MS=D3663796635A6C369F3340944A80791DE587959C
MS=msZW4-XV9-KM3
```

A bare `^MS=` also produced zero false positives here, but is left as a fallback since `MS=` is a
short, generic prefix.

## Note on TeamViewer

The existing `TeamViewer` entry describes TeamViewer Web Monitoring (`website: https://monitis.com`,
`scriptSrc: rum\.monitis\.com/`), whereas `teamviewer-sso-verification=` proves a TeamViewer SSO
tenant. The entry name and its categories (37 Network devices, 45 Control systems) fit the wider
product, so the key is added there — but if you would rather this token live on its own entry, say so
and I will split it out.

## Not proposed, on purpose

`google-site-verification=` matched **167 of 178 domains (850 records)**. It is used interchangeably
for Search Console, Workspace verification, Ads and more, so a fingerprint on it would fire almost
always while identifying almost nothing.
