### PR TITLE
Add dns.TXT fingerprints to Amazon SES, Cloudflare, Dynatrace and Salesforce

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -4846,7 +4846,8 @@
     "description": "Amazon Simple Email Service (SES) is an email service that enables developers to send mail from within any application.",
     "dns": {
       "TXT": [
-        "amazonses\\.com"
+        "amazonses\\.com",
+        "^amazonses:"
       ]
     },
     "icon": "Amazon SES.svg",

--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -5236,6 +5236,9 @@
       ],
       "SOA": [
         "\\.cloudflare\\.com"
+      ],
+      "TXT": [
+        "cloudflare_dashboard_sso="
       ]
     },
     "dom": [

--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -4489,6 +4489,11 @@
       "dtCookie1": ""
     },
     "description": "Dynatrace is a technology company that produces a software intelligence platform based on artificial intelligence to monitor and optimise application performance and development, IT infrastructure, and user experience for businesses and government agencies throughout the world.",
+    "dns": {
+      "TXT": [
+        "Dynatrace-site-verification="
+      ]
+    },
     "icon": "Dynatrace.svg",
     "js": {
       "dtrum": ""

--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -425,7 +425,8 @@
     "description": "Salesforce is a cloud computing service software (SaaS) that specializes in customer relationship management (CRM).",
     "dns": {
       "TXT": [
-        "salesforce\\.com"
+        "salesforce\\.com",
+        "^00D[A-Za-z0-9]{12}="
       ]
     },
     "html": [


### PR DESCRIPTION
Adds `dns.TXT` to three technologies that already exist in the catalog. No new entries, no new icons, no new categories.

## Method

Each pattern was compiled case-insensitively and run against a corpus of **6215 TXT records from
178 mutually independent apex domains** (no shared parent organisation; mixed geography and
industry; resolver `1.1.1.1`; multi-string TXT values concatenated before matching, as a standard
resolver does). A match on any record other than the intended vendor token counts as a false
positive. **There were none, for any pattern below.**

<details><summary>Calibration against patterns this catalog already accepts, same corpus</summary>

| Pattern already accepted upstream | Domains | Records |
|---|---|---|
| `anthropic-domain-verification` | 94 | 97 |
| `stripe-verification=` | 66 | 229 |
| `cursor-domain-verification` | 63 | 65 |
| `onetrust-domain-verification=` | 62 | 87 |
| `status-page-domain-verification=` | 35 | 40 |
| `notion-domain-verification=` | 28 | 33 |
| `mixpanel-domain-verify` | 27 | 30 |
| `dropbox-domain-verification` | 23 | 24 |
| `segment-site-verification` | 23 | 27 |
| `lovable_verification=` | 8 | 8 |
| `loom-verification` | 4 | 4 |
| `windsurf-verification=` | 4 | 4 |
| `heroku-domain-verification` | 0 | 0 |

</details>

### Dynatrace

Pattern: `Dynatrace-site-verification=` — **24 domains** / 47 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://apple.com
- https://assai.com.br
- https://bb.com.br
- https://bradesco.com.br
- https://carrefour.com
- https://cvc.com.br
- https://dell.com
- https://hm.com
- https://hp.com
- https://ibm.com
- https://infosys.com
- https://intel.com
- https://lenovo.com
- https://mastercard.com
- …and 10 more

</details>
### Salesforce

Pattern: `^00D[A-Za-z0-9]{12}=` — **20 domains** / 93 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://amazon.com
- https://bb.com.br
- https://bosch.com
- https://box.com
- https://bradesco.com.br
- https://carrefour.com
- https://github.com
- https://ibm.com
- https://ifood.com.br
- https://intel.com
- https://jumpcloud.com
- https://nvidia.com
- https://okta.com
- https://pagerduty.com
- …and 6 more

</details>
### Cloudflare

Pattern: `cloudflare_dashboard_sso=` — **16 domains** / 19 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://airtable.com
- https://caf.io
- https://cisco.com
- https://databricks.com
- https://elastic.co
- https://figma.com
- https://grammarly.com
- https://miro.com
- https://pagerduty.com
- https://philips.com
- https://santander.com.br
- https://sentry.io
- https://spotify.com
- https://sympla.com.br
- …and 2 more

</details>

## Notes

- **Salesforce** already declares `dns.TXT: salesforce\.com`, which does not match an organisation-id
  record such as `00Dbe000003Fnuj=1TBbe000000091h`. The added pattern is anchored and requires the
  `00D` + 12 alphanumerics + `=` shape, which produced no false positives across the corpus.
- **Cloudflare** gains the dashboard SSO token alongside its existing `NS` and `SOA` patterns. It
  proves a Cloudflare account with SSO configured, which the NS/SOA patterns miss for any domain not
  served through Cloudflare DNS.
- **Dynatrace** had no `dns` key at all. The token is emitted by Dynatrace's own domain verification
  flow; note the capital `D`, matched case-insensitively.
