### PR TITLE
Add Adobe, IBM and Yahoo entries detectable by dns.TXT

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -1851,6 +1851,20 @@
     ],
     "website": "https://adnymics.com"
   },
+  "Adobe": {
+    "cats": [
+      19
+    ],
+    "description": "Adobe enterprise domain claim, used by the Adobe Admin Console to verify ownership of a domain for Adobe identity management.",
+    "dns": {
+      "TXT": [
+        "adobe-idp-site-verification="
+      ]
+    },
+    "icon": "Adobe.svg",
+    "saas": true,
+    "website": "https://www.adobe.com"
+  },
   "Adobe Analytics": {
     "cats": [
       10

--- a/src/technologies/i.json
+++ b/src/technologies/i.json
@@ -111,6 +111,20 @@
     "saas": true,
     "website": "https://www.ibexa.co"
   },
+  "IBM": {
+    "cats": [
+      19
+    ],
+    "description": "IBM enterprise domain claim, used by IBMid to verify ownership of a domain for IBM Cloud and IBM account management.",
+    "dns": {
+      "TXT": [
+        "^ibmid="
+      ]
+    },
+    "icon": "IBM.svg",
+    "saas": true,
+    "website": "https://www.ibm.com"
+  },
   "IBM Carbon Design System": {
     "cats": [
       66

--- a/src/technologies/y.json
+++ b/src/technologies/y.json
@@ -27,6 +27,20 @@
     ],
     "website": "https://www.yachtsys.com"
   },
+  "Yahoo": {
+    "cats": [
+      19
+    ],
+    "description": "Yahoo domain verification, used to prove ownership of a domain to Yahoo services.",
+    "dns": {
+      "TXT": [
+        "yahoo-verification-key="
+      ]
+    },
+    "icon": "Yahoo.svg",
+    "saas": true,
+    "website": "https://www.yahoo.com"
+  },
   "Yahoo Advertising": {
     "cats": [
       36,


### PR DESCRIPTION
Adds three vendor-level entries whose domain-claim tokens are already provable, each reusing an icon that is present in the repository (`Adobe.svg`, `IBM.svg`, `Yahoo.svg`) — no new assets.

## Method

Each pattern was compiled case-insensitively and run against a corpus of **6215 TXT records from
178 mutually independent apex domains** (no shared parent organisation; mixed geography and
industry; resolver `1.1.1.1`; multi-string TXT values concatenated before matching, as a standard
resolver does). A match on any record other than the intended vendor token counts as a false
positive. **There were none, for any pattern below.**

<details><summary>Calibration against patterns this catalog already accepts, same corpus</summary>

| Pattern already accepted upstream | Domains | Records |
|---|---|---|
| `anthropic-domain-verification` | 94 | 97 |
| `stripe-verification=` | 66 | 229 |
| `cursor-domain-verification` | 63 | 65 |
| `onetrust-domain-verification=` | 62 | 87 |
| `status-page-domain-verification=` | 35 | 40 |
| `notion-domain-verification=` | 28 | 33 |
| `mixpanel-domain-verify` | 27 | 30 |
| `dropbox-domain-verification` | 23 | 24 |
| `segment-site-verification` | 23 | 27 |
| `lovable_verification=` | 8 | 8 |
| `loom-verification` | 4 | 4 |
| `windsurf-verification=` | 4 | 4 |
| `heroku-domain-verification` | 0 | 0 |

</details>

### Adobe

Pattern: `adobe-idp-site-verification=` — **83 domains** / 88 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://adyen.com
- https://airbnb.com
- https://akamai.com
- https://amd.com
- https://amplitude.com
- https://apple.com
- https://asana.com
- https://atlassian.com
- https://bb.com.br
- https://bbc.co.uk
- https://bosch.com
- https://caixa.gov.br
- https://calendly.com
- https://canva.com
- …and 69 more

</details>
### Yahoo

Pattern: `yahoo-verification-key=` — **13 domains** / 14 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://airbnb.com
- https://apple.com
- https://bbc.co.uk
- https://canva.com
- https://cisco.com
- https://hubspot.com
- https://jetbrains.com
- https://magazineluiza.com.br
- https://reuters.com
- https://santander.com.br
- https://seek.com.au
- https://shopify.com
- https://spotify.com

</details>
### IBM

Pattern: `^ibmid=` — **12 domains** / 13 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://adidas.com
- https://airtable.com
- https://amd.com
- https://bb.com.br
- https://confluent.io
- https://ikea.com
- https://intel.com
- https://kandji.io
- https://klarna.com
- https://petrobras.com.br
- https://santander.com.br
- https://weg.net

</details>

## Notes

- `adobe-idp-site-verification=` corroborates on more domains than every `dns.TXT` pattern currently
  in the catalog except `anthropic-domain-verification`.
- Each token is organisation-level and does not identify which product the tenant uses, so these are
  vendor-level entries rather than keys on one of the existing `Adobe *`, `IBM *` or `Yahoo *`
  product entries. For the same reason all three are filed under `19` Miscellaneous rather than
  claiming a product category. Happy to rename or recategorise to whatever convention you prefer.
