### PR TITLE
Add dns.TXT fingerprints to Docker, Atlassian Cloud, Drift, Pendo, Airtable, Linear and Loom

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -3350,6 +3350,11 @@
     "dom": [
       "iframe[scr*='//airtable.com/'], a[href*='//airtable.com/'][target='_blank']"
     ],
+    "dns": {
+      "TXT": [
+        "airtable-verification="
+      ]
+    },
     "icon": "Airtable.svg",
     "pricing": [
       "freemium",
@@ -8429,7 +8434,8 @@
     "description": "Atlassian Cloud is the hosted platform behind Atlassian products such as Jira, Confluence and Bitbucket.",
     "dns": {
       "TXT": [
-        "atlassian-domain-verification="
+        "atlassian-domain-verification=",
+        "atlassian-sending-domain-verification="
       ]
     },
     "icon": "Atlassian.svg",

--- a/src/technologies/d.json
+++ b/src/technologies/d.json
@@ -2751,6 +2751,11 @@
     "html": [
       "<!-- This comment is expected by the docker HEALTHCHECK  -->"
     ],
+    "dns": {
+      "TXT": [
+        "docker-verification="
+      ]
+    },
     "icon": "Docker.svg",
     "website": "https://www.docker.com/"
   },
@@ -3846,6 +3851,11 @@
       52
     ],
     "description": "Drift is a conversational marketing platform.",
+    "dns": {
+      "TXT": [
+        "drift-domain-verification="
+      ]
+    },
     "icon": "Drift.svg",
     "js": {
       "drift": "",

--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -2144,6 +2144,11 @@
       53
     ],
     "description": "Linear is a platform for collecting payments and managing business operations, offering sales and marketing tools for real estate agents, extending beyond a traditional brokerage system.",
+    "dns": {
+      "TXT": [
+        "linear-domain-verification="
+      ]
+    },
     "icon": "Linear.svg",
     "js": {
       "linearFrontend": ""
@@ -3742,7 +3747,8 @@
     ],
     "dns": {
       "TXT": [
-        "loom-verification"
+        "loom-verification",
+        "loom-site-verification="
       ]
     },
     "icon": "Loom.svg",

--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -2236,6 +2236,11 @@
       58
     ],
     "description": "Pendo is a product analytics platform used in release to enrich the product experience and provide insights to the product management team.",
+    "dns": {
+      "TXT": [
+        "pendo-domain-verification="
+      ]
+    },
     "icon": "Pendo.svg",
     "js": {
       "pendo.HOST": "\\.pendo\\.io",


### PR DESCRIPTION
Adds `dns.TXT` to seven technologies that already exist in the catalog. No new entries, no new icons, no new categories.

## Method

Each pattern was compiled case-insensitively and run against a corpus of **6215 TXT records from
178 mutually independent apex domains** (no shared parent organisation; mixed geography and
industry; resolver `1.1.1.1`; multi-string TXT values concatenated before matching). A match on any
record other than the intended vendor token counts as a false positive. **There were none.**

<details><summary>Calibration against patterns already in the catalog, same corpus</summary>

| Pattern | Domains | Records |
|---|---|---|
| `anthropic-domain-verification` | 94 | 97 |
| `adobe-idp-site-verification=` | 83 | 88 |
| `stripe-verification=` | 66 | 229 |
| `notion-domain-verification=` | 28 | 33 |
| `dropbox-domain-verification` | 23 | 24 |
| `lovable_verification=` | 8 | 8 |
| `loom-verification` | 4 | 4 |
| `heroku-domain-verification` | 0 | 0 |

</details>

### Docker

Pattern: `docker-verification=` — **74 domains** / 75 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://1password.com
- https://adyen.com
- https://airtable.com
- https://amazon.com
- https://amd.com
- https://amplitude.com
- https://asana.com
- https://bbc.co.uk
- https://bosch.com
- https://canva.com
- https://carrefour.com
- https://cisco.com
- https://cloudflare.com
- https://confluent.io
- …and 60 more

</details>
### Atlassian Cloud

Pattern: `atlassian-sending-domain-verification=` — **25 domains** / 28 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://amplitude.com
- https://atlassian.com
- https://bosch.com
- https://ibm.com
- https://klarna.com
- https://lyft.com
- https://mastercard.com
- https://nike.com
- https://nytimes.com
- https://paytm.com
- https://qualcomm.com
- https://rapid7.com
- https://revolut.com
- https://sentinelone.com
- …and 11 more

</details>
### Drift

Pattern: `drift-domain-verification=` — **23 domains** / 24 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://1password.com
- https://airtable.com
- https://akamai.com
- https://asana.com
- https://box.com
- https://canva.com
- https://cloudflare.com
- https://confluent.io
- https://elastic.co
- https://fastly.com
- https://figma.com
- https://gitlab.com
- https://grammarly.com
- https://jamf.com
- …and 9 more

</details>
### Pendo

Pattern: `pendo-domain-verification=` — **23 domains** / 29 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://amazon.com
- https://atlassian.com
- https://box.com
- https://calendly.com
- https://cisco.com
- https://clickup.com
- https://fortinet.com
- https://hashicorp.com
- https://hp.com
- https://ikea.com
- https://jpmorgan.com
- https://jumpcloud.com
- https://kandji.io
- https://lenovo.com
- …and 9 more

</details>
### Airtable

Pattern: `airtable-verification=` — **22 domains** / 33 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://atlassian.com
- https://bloomberg.com
- https://caf.io
- https://canva.com
- https://cisco.com
- https://crowdstrike.com
- https://docker.com
- https://hashicorp.com
- https://hp.com
- https://ikea.com
- https://jetbrains.com
- https://jpmorgan.com
- https://lenovo.com
- https://lyft.com
- …and 8 more

</details>
### Linear

Pattern: `linear-domain-verification=` — **13 domains** / 15 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://figma.com
- https://loom.com
- https://meta.com
- https://microsoft.com
- https://mixpanel.com
- https://monzo.com
- https://netlify.com
- https://okta.com
- https://sentry.io
- https://shopify.com
- https://snowflake.com
- https://snyk.io
- https://sympla.com.br

</details>
### Loom

Pattern: `loom-site-verification=` — **9 domains** / 9 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://calendly.com
- https://clickup.com
- https://github.com
- https://hashicorp.com
- https://hotmart.com
- https://okta.com
- https://sentinelone.com
- https://spotify.com
- https://twilio.com

</details>

## Notes

- **Docker** had no `dns` key. The token proves a Docker organisation (Docker Hub / Docker Business),
  which is a different signal from the existing `html` pattern — worth stating plainly so the
  semantics are on the record.
- **Atlassian Cloud** gains a second token. `atlassian-sending-domain-verification=` verifies a domain
  used to *send* mail from Atlassian products and appears on 25 domains, including several that do
  not carry `atlassian-domain-verification=`.
- **Loom** gains `loom-site-verification=`. The `loom-verification` pattern already in the catalog
  matches only 4 domains in this corpus; with the second shape the union is 13.
