### PR TITLE
Add Meta and Postman entries detectable by dns.TXT

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -3381,6 +3381,20 @@
     ],
     "website": "https://messagemedia.com"
   },
+  "Meta": {
+    "cats": [
+      19
+    ],
+    "description": "Meta domain verification, used by Meta Business to prove ownership of a domain for Facebook and Instagram business assets.",
+    "dns": {
+      "TXT": [
+        "facebook-domain-verification="
+      ]
+    },
+    "icon": "Meta.svg",
+    "saas": true,
+    "website": "https://about.meta.com"
+  },
   "MetaMap": {
     "cats": [
       69

--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -6143,6 +6143,20 @@
     ],
     "website": "https://postie.com"
   },
+  "Postman": {
+    "cats": [
+      47
+    ],
+    "description": "Postman is an API development and testing platform.",
+    "dns": {
+      "TXT": [
+        "postman-domain-verification="
+      ]
+    },
+    "icon": "PostmanAPIDocumentation.svg",
+    "saas": true,
+    "website": "https://www.postman.com"
+  },
   "Postman API Documentation": {
     "cats": [
       4


### PR DESCRIPTION
Adds two vendor-level entries, each reusing an icon already present in the repository — no new assets.

## Method

Each pattern was compiled case-insensitively and run against a corpus of **6215 TXT records from
178 mutually independent apex domains** (no shared parent organisation; mixed geography and
industry; resolver `1.1.1.1`; multi-string TXT values concatenated before matching). A match on any
record other than the intended vendor token counts as a false positive. **There were none.**

<details><summary>Calibration against patterns already in the catalog, same corpus</summary>

| Pattern | Domains | Records |
|---|---|---|
| `anthropic-domain-verification` | 94 | 97 |
| `adobe-idp-site-verification=` | 83 | 88 |
| `stripe-verification=` | 66 | 229 |
| `notion-domain-verification=` | 28 | 33 |
| `dropbox-domain-verification` | 23 | 24 |
| `lovable_verification=` | 8 | 8 |
| `loom-verification` | 4 | 4 |
| `heroku-domain-verification` | 0 | 0 |

</details>

### Meta

Pattern: `facebook-domain-verification=` — **72 domains** / 74 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://airbnb.com
- https://airtable.com
- https://amazon.com
- https://apple.com
- https://asana.com
- https://atlassian.com
- https://bb.com.br
- https://bosch.com
- https://calendly.com
- https://canva.com
- https://cisco.com
- https://clickup.com
- https://cloudflare.com
- https://confluent.io
- …and 58 more

</details>
### Postman

Pattern: `postman-domain-verification=` — **31 domains** / 33 records, 0 false positives.

<details><summary>Domains carrying the record</summary>

- https://adyen.com
- https://airtable.com
- https://atlassian.com
- https://calendly.com
- https://canva.com
- https://cisco.com
- https://clickup.com
- https://elastic.co
- https://figma.com
- https://grammarly.com
- https://infosys.com
- https://jamf.com
- https://kandji.io
- https://mastercard.com
- …and 17 more

</details>

## Notes

- **Meta** — `facebook-domain-verification=` is the token Meta Business asks tenants to publish to
  claim a domain for Facebook and Instagram business assets. The catalog has six Facebook product
  entries plus `Workplace by Meta`, and this token identifies none of them, so it is filed as a
  vendor-level entry reusing `Meta.svg`. Happy to rename it to `Meta Business Manager` if you prefer
  the product name.
- **Postman** — `Postman API Documentation` (cats 4) detects published API docs in the front end. This
  token proves a Postman team account instead, so it is a separate entry under `47` Development,
  reusing `PostmanAPIDocumentation.svg`.
- Both are `19` Miscellaneous / `47` Development respectively; categories are suggestions.
