### PR TITLE
Add Google Cloud DNS technology

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -3029,6 +3029,22 @@
     ],
     "website": "https://cloud.google.com/cdn"
   },
+  "Google Cloud DNS": {
+    "cats": [
+      88
+    ],
+    "description": "Google Cloud DNS is Google's authoritative DNS service; domains using it are served by ns-cloud-*.googledomains.com nameservers.",
+    "dns": {
+      "NS": [
+        "ns-cloud-[a-z]\\d\\.googledomains\\.com"
+      ],
+      "SOA": [
+        "ns-cloud-[a-z]\\d\\.googledomains\\.com"
+      ]
+    },
+    "icon": "Google Cloud.svg",
+    "website": "https://cloud.google.com/dns"
+  },
   "Google Cloud Load Balancing": {
     "cats": [
       65


### PR DESCRIPTION
Add Google Cloud DNS to the technologies database.

Detection via dns NS: `ns-cloud-[a-z]\d\.googledomains\.com`
Detection via dns SOA: `ns-cloud-[a-z]\d\.googledomains\.com`
Category: Hosting (88)
Website: https://cloud.google.com/dns
Lives examples: https://byhiswillbrand.com, https://claramonroe.com
