### PR TITLE
Add Cloudflare DNS technology

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -5303,6 +5303,22 @@
     ],
     "website": "https://www.cloudflare.com"
   },
+  "Cloudflare DNS": {
+    "cats": [
+      88
+    ],
+    "description": "Cloudflare DNS is Cloudflare's authoritative DNS service; domains using it are served by *.ns.cloudflare.com nameservers.",
+    "dns": {
+      "NS": [
+        "\\.ns\\.cloudflare\\.com"
+      ],
+      "SOA": [
+        "\\.ns\\.cloudflare\\.com"
+      ]
+    },
+    "icon": "CloudFlare.svg",
+    "website": "https://www.cloudflare.com/application-services/products/dns/"
+  },
   "Cloudflare Rocket Loader": {
     "cats": [
       92


### PR DESCRIPTION
Add Cloudflare DNS to the technologies database.

Detection via dns NS: `\.ns\.cloudflare\.com`
Detection via dns SOA: `\.ns\.cloudflare\.com`
Category: Hosting (88)
Website: https://www.cloudflare.com/application-services/products/dns/
Lives examples: https://21run.com, https://24timezones.com
