### PR TITLE
Add Amazon Route 53 technology

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -4840,6 +4840,22 @@
       "payments\\.amazon\\.com"
     ]
   },
+  "Amazon Route 53": {
+    "cats": [
+      88
+    ],
+    "description": "Amazon Route 53 is AWS's authoritative DNS service; domains using it are served by awsdns nameservers.",
+    "dns": {
+      "NS": [
+        "\\.awsdns-\\d+\\."
+      ],
+      "SOA": [
+        "\\.awsdns-\\d+\\."
+      ]
+    },
+    "icon": "Amazon Web Services.svg",
+    "website": "https://aws.amazon.com/route53/"
+  },
   "Amazon S3": {
     "cats": [
       31


### PR DESCRIPTION
Add Amazon Route 53 to the technologies database.

Detection via dns NS: `\.awsdns-\d+\.`
Detection via dns SOA: `\.awsdns-\d+\.`
Category: Hosting (88)
Website: https://aws.amazon.com/route53/
Lives examples: https://4over.com, https://6sense.com
