### PR TITLE
Add Omago technology

### DIFF
--- a/src/images/icons/Omago.svg
+++ b/src/images/icons/Omago.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 130 130" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="65" cy="65" r="52" stroke="#0A0A0A" stroke-width="26"/>
+  <circle cx="106" cy="116" r="14" fill="#39FF14"/>
+</svg>

--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -669,6 +669,26 @@
     ],
     "website": "https://omacro.com"
   },
+  "Omago": {
+    "cats": [
+      52
+    ],
+    "description": "Omago is an AI customer-service assistant for business websites that answers visitor questions in the customer's own language, captures leads and hands conversations over to WhatsApp.",
+    "dom": [
+      "#omago-widget-container",
+      "#omago-widget-button"
+    ],
+    "icon": "Omago.svg",
+    "pricing": [
+      "freemium",
+      "recurring"
+    ],
+    "saas": true,
+    "scriptSrc": [
+      "app\\.omago\\.ai/widget\\.js"
+    ],
+    "website": "https://omago.ai"
+  },
   "Omeda": {
     "cats": [
       86,


### PR DESCRIPTION
Adds detection for [Omago](https://omago.ai), an AI customer-service assistant (live chat) widget for business websites.

**Detection:**
- `scriptSrc`: `app\.omago\.ai/widget\.js` — the widget's only loader URL
- `dom`: `#omago-widget-container`, `#omago-widget-button` — stable element IDs the widget injects

**Live websites using it** (all verified today):
1. https://reaphk.com
2. https://license.reaphk.com
3. https://surplushk.com
4. https://bridgenote.ca
5. https://treehousecpa.com
6. https://hokkaidocake.ca
7. https://hokkaidocake.omago.ai (same site, second domain)
8. https://demo.omago.ai
9. https://omago.ai

Note: this is 9 links rather than the 10 the contributing guide asks for — Omago is an early-stage product and these are all current live installs; happy to add more as they ship, or hold the PR until a 10th is live if preferred.

Category 52 (Live chat), SaaS, freemium/recurring pricing. Icon is the product's current official mark (SVG). Schema and order validators pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Af3FTcArB3S25aJ6smM6g