### PR TITLE
Improve WooCommerce Subscriptions detection

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -3627,7 +3627,6 @@
     "scriptSrc": [
       "^(?!.*?/wp-content/plugins/[^/]+/js/integrations/woocommerce\\.js(?:\\?ver=[\\d.]+)?$).*woocommerce",
       "^(?!.*?/wp-content/plugins/[^/]+/js/integrations/woocommerce\\.js(?:\\?ver=[\\d.]+)?$).*/woocommerce(?:\\.min)?\\.js(?:\\?ver=([0-9.]+))?\\;version:\\1"
-
     ],
     "website": "https://woocommerce.com"
   },
@@ -3741,7 +3740,12 @@
     ],
     "description": "WooCommerce Subscriptions primarily allows you to create and sell subscription products from your WooCommerce shop.",
     "dom": [
-      "link[href*='/wp-content/plugins/woocommerce-subscriptions/']"
+      "link[href*='/wp-content/plugins/woocommerce-subscriptions/']",
+      "link[href*=\"/plugins/woocommerce-subscriptions/\"]",
+      "script[src*=\"/plugins/woocommerce-subscriptions/\"]"
+    ],
+    "html": [
+      "/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/build"
     ],
     "icon": "WooCommerce.svg",
     "implies": [


### PR DESCRIPTION
Improve WooCommerce Subscriptions detection in the technologies database.

Detection via dom: `link[href*="/plugins/woocommerce-subscriptions/"]` (also matches non-standard wp-content directories)
Detection via dom: `script[src*="/plugins/woocommerce-subscriptions/"]`
Detection via html: `/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/build`
Category: WordPress plugins (87)
Website: https://woocommerce.com/products/woocommerce-subscriptions
Lives examples: https://aiwfonline.com, https://anuttaraworldwide.com, https://apsi.co.uk, https://awakenrituals.com, https://babyboytreats.com, https://belizehousehunters.com, https://changeovertimelc.com, https://diyeliquids.co.uk, https://drdwaynejackson.com, https://elisagiuli.com
