### PR TITLE
Improve Giosg detection

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1279,7 +1279,8 @@
     ],
     "saas": true,
     "scripts": [
-      "service\\.giosg\\.com"
+      "service\\.giosg\\.com",
+      "giosg\\.com"
     ],
     "website": "https://www.giosg.com"
   },


### PR DESCRIPTION
Improve Giosg detection in the technologies database.

Detection via scriptSrc: `giosg\.com` script source (loader is also served from giosg.com hosts other than service.giosg.com)
Category: Live chat (52)
Website: https://www.giosg.com
Lives examples: https://a1.rs, https://netrauta.fi, https://apotek1.no, https://a1.hr, https://hyundai.com.mx, https://tokmanni.fi, https://leikkiturva.fi, https://reality.sk
