### PR TITLE
Add Natro technology

### DIFF
--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -335,6 +335,19 @@
     ],
     "website": "https://www.nativo.com"
   },
+  "Natro": {
+    "cats": [
+      88
+    ],
+    "description": "Natro is a Turkish web hosting and domain registration provider; hosted domains use natrohost.com nameservers.",
+    "dns": {
+      "NS": [
+        "natrohost\\.com",
+        "natro\\.com"
+      ]
+    },
+    "website": "https://www.natro.com"
+  },
   "Natural Intelligence": {
     "cats": [
       96


### PR DESCRIPTION
Add Natro to the technologies database.

Detection via dns NS: `natrohost\.com`
Detection via dns NS: `natro\.com`
Category: Hosting (88)
Website: https://www.natro.com
Lives examples: https://nolvahome.com
