### PR TITLE
Add Lotame technology

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -3932,6 +3932,20 @@
     "saas": true,
     "website": "https://www.loqate.com"
   },
+  "Lotame": {
+    "cats": [
+      97,
+      36
+    ],
+    "description": "Lotame is a data management platform (DMP) providing audience data collection, segmentation and identity solutions via its Crowd Control tag.",
+    "scriptSrc": [
+      "\\.crwdcntrl\\.net/"
+    ],
+    "website": "https://www.lotame.com",
+    "xhr": [
+      "\\.crwdcntrl\\.net"
+    ]
+  },
   "LotLinx": {
     "cats": [
       32


### PR DESCRIPTION
Add Lotame to the technologies database.

Detection via scriptSrc: `\.crwdcntrl\.net/` script source
Detection via xhr: `\.crwdcntrl\.net`
Category: Customer data platform (97), Advertising (36)
Website: https://www.lotame.com
Lives examples: https://qconline.com, https://thestar.com, https://runnersworld.com, https://si.com, https://cbc.ca, https://rapidcityjournal.com
