### PR TITLE
Add Flyads technology

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -3001,6 +3001,19 @@
     ],
     "website": "https://fly.io"
   },
+  "Flyads": {
+    "cats": [
+      36
+    ],
+    "cookies": {
+      "flyid": ""
+    },
+    "description": "Flyads is an ad network serving from fly.codes and displayfly.com hosts and setting the flyid cookie.",
+    "website": "https://displayfly.com",
+    "xhr": [
+      "(?:\\.fly\\.codes|\\.displayfly\\.com)"
+    ]
+  },
   "Flybook": {
     "cats": [
       93


### PR DESCRIPTION
Add Flyads to the technologies database.

Detection via cookie: `flyid`
Detection via xhr: `(?:\.fly\.codes|\.displayfly\.com)`
Category: Advertising (36)
Website: https://displayfly.com
Lives examples: https://www.online-translator.com
