### PR TITLE
Add PTisp technology

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -8513,6 +8513,18 @@
     "oss": true,
     "website": "https://pterodactyl.io"
   },
+  "PTisp": {
+    "cats": [
+      88
+    ],
+    "description": "PTisp is a Portuguese hosting provider; hosted domains use mydnspt.net nameservers.",
+    "dns": {
+      "NS": [
+        "\\.mydnspt\\.net"
+      ]
+    },
+    "website": "https://ptisp.pt"
+  },
   "PTminder": {
     "cats": [
       53


### PR DESCRIPTION
Add PTisp to the technologies database.

Detection via dns NS: `\.mydnspt\.net`
Category: Hosting (88)
Website: https://ptisp.pt
Lives examples: https://www.cenjor.pt
