### PR TITLE
Add Peer39 technology

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -2089,6 +2089,22 @@
     "saas": true,
     "website": "https://www.peel.fr"
   },
+  "Peer39": {
+    "cats": [
+      36
+    ],
+    "description": "Peer39 is a contextual page-quality and ad-intelligence service used pre-bid in programmatic advertising.",
+    "html": [
+      "tags\\.peer39\\.com"
+    ],
+    "scriptSrc": [
+      "\\.peer39\\.(?:com|net)/"
+    ],
+    "website": "https://www.peer39.com",
+    "xhr": [
+      "\\.peer39\\.(?:com|net)"
+    ]
+  },
   "PeerBoard": {
     "cats": [
       2


### PR DESCRIPTION
Add Peer39 to the technologies database.

Detection via scriptSrc: `\.peer39\.(?:com|net)/` script source
Detection via xhr: `\.peer39\.(?:com|net)`
Detection via html: `tags\.peer39\.com`
Category: Advertising (36)
Website: https://www.peer39.com
Lives examples: https://skysports.com
